### PR TITLE
custom_729 should extend from bedrock_712, not 686

### DIFF
--- a/src/main/java/dev/waterdog/waterdogpe/CustomNetworkSettings.java
+++ b/src/main/java/dev/waterdog/waterdogpe/CustomNetworkSettings.java
@@ -54,7 +54,7 @@ public class CustomNetworkSettings extends Bedrock_v729 {
             .insert(63, ContainerSlotType.DYNAMIC_CONTAINER)
             .build();
 
-    public static final BedrockCodec CODEC = Bedrock_v686.CODEC.toBuilder()
+    public static final BedrockCodec CODEC = Bedrock_v712.CODEC.toBuilder()
             .raknetProtocolVersion(11)
             .protocolVersion(729)
             .minecraftVersion("1.21.30")


### PR DESCRIPTION
This one fixes problems that was encountered when using proxy transfer (change dimension for 729 was serialized as if it was for 686, not 712 (with recent changes)), and many other problems.

From waterdog logs (when trying to transfer on 1.21.30)
```
Received violation from Yexeed: PacketViolationWarningPacket(type=MALFORMED_PACKET, severity=TERMINATING_CONNECTION, packetCauseId=61, context=BinaryStream read() overflow checkedNumber = 16, mReadPointer = 15, buffer Length is = 15 bytes
```